### PR TITLE
Awhigham9/improve command importing

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -10,9 +10,12 @@ const commands: { [commandName: string]: ICommand } = {};
 const commandFiles = fs.readdirSync(path.join(__dirname, commandDir))
                         .filter((file : string) => file.endsWith('.ts'));
 for (const file of commandFiles) {
-	const availableCommands: ICommand[] = require(`./commands/${file}`).getCommands();
-	for (const command of availableCommands) {
-		commands[command.name] = command;
+	const module = require(`./commands/${file}`);
+	if (module.getCommands) {
+		const availableCommands: ICommand[] = module.getCommands();
+		for (const command of availableCommands) {
+			commands[command.name] = command;
+		}
 	}
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -16,6 +16,4 @@ for (const file of commandFiles) {
 	}
 }
 
-console.log(commands);
-
 export default commands;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -10,8 +10,12 @@ const commands: { [commandName: string]: ICommand } = {};
 const commandFiles = fs.readdirSync(path.join(__dirname, commandDir))
                         .filter((file : string) => file.endsWith('.ts'));
 for (const file of commandFiles) {
-	const command: ICommand = require(`./commands/${file}`).default;
-	commands[command.name] = command;
+	const availableCommands: ICommand[] = require(`./commands/${file}`).getCommands();
+	for (const command of availableCommands) {
+		commands[command.name] = command;
+	}
 }
+
+console.log(commands);
 
 export default commands;

--- a/src/commands/orange.ts
+++ b/src/commands/orange.ts
@@ -9,4 +9,8 @@ export const Orange: ICommand = {
     }
 }
 
+export function getCommands(): ICommand[] {
+    return [Orange];
+};
+
 export default Orange;

--- a/src/commands/orange.ts
+++ b/src/commands/orange.ts
@@ -12,5 +12,3 @@ export const Orange: ICommand = {
 export function getCommands(): ICommand[] {
     return [Orange];
 };
-
-export default Orange;

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -9,4 +9,8 @@ export const Ping: ICommand = {
     }
 }
 
+export function getCommands(): ICommand[] {
+    return [Ping];
+};
+
 export default Ping;

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -12,5 +12,3 @@ export const Ping: ICommand = {
 export function getCommands(): ICommand[] {
     return [Ping];
 };
-
-export default Ping;

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -14,4 +14,8 @@ export const Server: ICommand = {
     }
 }
 
+export function getCommands(): ICommand[] {
+    return [Server];
+};
+
 export default Server;

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -17,5 +17,3 @@ export const Server: ICommand = {
 export function getCommands(): ICommand[] {
     return [Server];
 };
-
-export default Server;

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -12,5 +12,3 @@ export const User: ICommand = {
 export function getCommands(): ICommand[] {
     return [User];
 };
-
-export default User;

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -9,4 +9,8 @@ export const User: ICommand = {
     }
 }
 
+export function getCommands(): ICommand[] {
+    return [User];
+};
+
 export default User;


### PR DESCRIPTION
Change how `commands.ts` loads all commands at runtime to be more readable and extensible.

Previously, `commands.ts` would load all commands by importing all modules under `src/commands/` and assuming the default import from a module is the command. That is, any file in `src/commands/` must adhere to the following strict structure where the default export *must* be a command:
```typescript
const foo: ICommand  = {
    // code
}

export default foo;
```

This has two negative effects. First, this is not readable and makes the later import in the KV store in `commands.ts` non-obvious.
Second, it is not extensible because it prevents files under `src/commands/` from being able to export default items which are *not* commands and makes it impossible for a single file to export multiple commands. Either of these may be desirable in the future.

The proposed solution is to have files which offer commands to `commands.ts` export a function called `getCommands`. This name is standard across the code base. This solves the first issue by making the intended goal of the function explicit, and it solves the second by allowing variable default exports and multiple command exports.

It looks like this:
```typescript
const foo: ICommand  = {
    // code
}

export function getCommand(): ICommand[] {
    return [foo];
}
```

A multiple command export could have a multi-item list in the `return` statement.